### PR TITLE
Add interactive setup script, README, and env-based config

### DIFF
--- a/.env-example
+++ b/.env-example
@@ -1,5 +1,8 @@
 NGINX_VERSION=1.21-alpine
 NGINX_CONF_DIR=./data/nginx/conf.d
+DOMAIN_NAME=example.com
+CERTBOT_EMAIL=
+CERTBOT_STAGING=0
 
 CERTBOT_CONF_DIR=./data/certbot/conf
 CERTBOT_WWW_DIR=./data/certbot/www

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 .env
+data/certbot/
+data/nginx/conf.d/app.conf

--- a/README.md
+++ b/README.md
@@ -1,0 +1,80 @@
+# nginx + Let's Encrypt SSL
+
+Быстрое развёртывание HTTPS-сервера с автоматическими SSL-сертификатами от Let's Encrypt.
+
+## Требования
+
+- [Docker](https://docs.docker.com/get-docker/)
+- [Docker Compose](https://docs.docker.com/compose/install/) (плагин, не legacy `docker-compose`)
+- `curl`
+- Домен, DNS которого резолвится на IP вашего сервера
+- Порты **80** и **443** доступны снаружи (не закрыты файерволом)
+
+## Быстрый старт
+
+```bash
+git clone <repo-url>
+cd nginx-certbot
+bash setup.sh
+```
+
+Скрипт сам запросит у вас домен, email и все нужные параметры, сгенерирует конфиг и стартует сервер с SSL.
+
+## Структура проекта
+
+```
+nginx-certbot/
+├── setup.sh                          # Главный скрипт — точка входа
+├── init-letsencrypt.sh               # Логика получения сертификата
+├── docker-compose.yml                # nginx + certbot контейнеры
+├── .env-example                      # Шаблон переменных окружения
+├── .env                              # Конфиг (создаётся setup.sh, не в git)
+├── data/
+│   ├── nginx/conf.d/
+│   │   └── app.conf-template         # Nginx конфиг (подстановка домена через envsubst)
+│   └── certbot/                      # Сертификаты и TLS-параметры (создаётся в runtime)
+└── sites/
+    └── index.html                    # Контент сайта — кладите свои файлы сюда
+```
+
+## Как это работает
+
+1. `setup.sh` собирает ввод и генерирует `.env`
+2. `init-letsencrypt.sh` создаёт временный сертификат, стартует nginx, затем запрашивает реальный сертификат у Let's Encrypt через ACME webroot-валидацию
+3. nginx перезагружается с реальным сертификатом
+4. Контейнер `certbot` автоматически обновляет сертификат каждые 12 часов (проверка), nginx перезагружается каждые 6 часов чтобы подхватить обновлённый сертификат
+
+## Параметры .env
+
+| Переменная        | Описание                                                                 |
+|-------------------|--------------------------------------------------------------------------|
+| `DOMAIN_NAME`     | Ваш домен (например `example.com`)                                       |
+| `CERTBOT_EMAIL`   | Email для уведомлений от Let's Encrypt (оставить пустым — без email)      |
+| `CERTBOT_STAGING` | `1` для тестирования (staging-сертификат, не входит в rate-limit)         |
+
+## Частые команды
+
+```bash
+# Посмотреть логи
+docker compose logs -f
+
+# Остановить сервер
+docker compose down
+
+# Перезапустить сервер
+docker compose up -d
+
+# Заново получить сертификат (например при смене домена)
+docker compose down
+rm -rf data/certbot
+bash setup.sh
+```
+
+## Частые проблемы
+
+| Проблема | Решение |
+|----------|---------|
+| `Connection refused` при валидации | Порт 80 закрыт файерволом или занят другим процессом |
+| `too many requests` от Let's Encrypt | Превышен rate-limit. Пересапустите setup.sh и выберите staging-режим для тестирования |
+| Сертификат не обновляется | Проверьте `docker compose logs certbot` |
+| Nginx не стартует | Проверьте `docker compose logs nginx` — скорее всего проблема с конфигом или сертификатом |

--- a/data/nginx/conf.d/app.conf-template
+++ b/data/nginx/conf.d/app.conf-template
@@ -1,9 +1,9 @@
 server {
     listen 80;
-    server_name YOUR_DOMAIN; # Replace YOUR_DOMAIN with actual info
+    server_name ${DOMAIN_NAME};
     location / {
         return 301 https://$host$request_uri;
-    }    
+    }
 
     location /.well-known/acme-challenge/ {
         root /var/www/certbot;
@@ -11,14 +11,14 @@ server {
 }
 server {
     listen 443 ssl;
-    server_name YOUR_DOMAIN; # Replace YOUR_DOMAIN with actual info
-    
+    server_name ${DOMAIN_NAME};
+
     location / {
-       root /sites; # Path to mapped data directory for nginx via docker-compose.yml
+       root /sites;
     }
-	
-    ssl_certificate /etc/letsencrypt/live/YOUR_DOMAIN/fullchain.pem; # Replace YOUR_DOMAIN with actual info
-    ssl_certificate_key /etc/letsencrypt/live/YOUR_DOMAIN/privkey.pem; # Replace YOUR_DOMAIN with actual info
+
+    ssl_certificate /etc/letsencrypt/live/${DOMAIN_NAME}/fullchain.pem;
+    ssl_certificate_key /etc/letsencrypt/live/${DOMAIN_NAME}/privkey.pem;
     include /etc/letsencrypt/options-ssl-nginx.conf;
     ssl_dhparam /etc/letsencrypt/ssl-dhparams.pem;
 }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,12 +5,14 @@ services:
     ports:
       - "80:80"
       - "443:443"
+    environment:
+      - DOMAIN_NAME=${DOMAIN_NAME}
     volumes:
       - ${NGINX_CONF_DIR}:/etc/nginx/conf.d
       - ${CERTBOT_CONF_DIR}:/etc/letsencrypt
       - ${CERTBOT_WWW_DIR}:/var/www/certbot
       - ${SITES_DIR}:/sites
-    command: "/bin/sh -c 'while :; do sleep 6h & wait $${!}; nginx -s reload; done & nginx -g \"daemon off;\"'"
+    command: "/bin/sh -c 'envsubst \"\\${DOMAIN_NAME}\" < /etc/nginx/conf.d/app.conf-template > /etc/nginx/conf.d/app.conf && while :; do sleep 6h & wait $${!}; nginx -s reload; done & nginx -g \"daemon off;\"'"
     
   certbot:
     image: certbot/certbot

--- a/init-letsencrypt.sh
+++ b/init-letsencrypt.sh
@@ -1,24 +1,26 @@
 #!/bin/bash
+set -e
 
-if ! [ -x "$(command -v docker-compose)" ]; then
-  echo 'Error: docker-compose is not installed.' >&2
+# ─── Load .env ─────────────────────────────────────────────
+if [ ! -f .env ]; then
+  echo '[ERROR] .env file not found. Run setup.sh first.' >&2
+  exit 1
+fi
+export $(grep -v '^#' .env | xargs)
+
+# ─── Variables ─────────────────────────────────────────────
+domain="$DOMAIN_NAME"
+rsa_key_size=4096
+data_path="./data/certbot"
+email="$CERTBOT_EMAIL"
+staging="${CERTBOT_STAGING:-0}"
+
+if [[ -z "$domain" ]]; then
+  echo '[ERROR] DOMAIN_NAME is not set in .env' >&2
   exit 1
 fi
 
-domains=(YOUR_DOMAIN_HERE)
-rsa_key_size=4096
-data_path="./data/certbot" # Path to mapped data directory for certbot & nginx via docker-compose.yml
-email="" # Adding a valid address is strongly recommended
-staging=0 # Set to 1 if you're testing your setup to avoid hitting request limits
-
-if [ -d "$data_path" ]; then
-  read -p "Existing data found for $domains. Continue and replace existing certificate? (y/N) " decision
-  if [ "$decision" != "Y" ] && [ "$decision" != "y" ]; then
-    exit
-  fi
-fi
-
-
+# ─── TLS params ────────────────────────────────────────────
 if [ ! -e "$data_path/conf/options-ssl-nginx.conf" ] || [ ! -e "$data_path/conf/ssl-dhparams.pem" ]; then
   echo "### Downloading recommended TLS parameters ..."
   mkdir -p "$data_path/conf"
@@ -27,46 +29,44 @@ if [ ! -e "$data_path/conf/options-ssl-nginx.conf" ] || [ ! -e "$data_path/conf/
   echo
 fi
 
-echo "### Creating dummy certificate for $domains ..."
-path="/etc/letsencrypt/live/$domains"
-mkdir -p "$data_path/conf/live/$domains"
-docker-compose run --rm --entrypoint "\
+# ─── Dummy cert (nginx needs a cert to start) ─────────────
+echo "### Creating dummy certificate for $domain ..."
+path="/etc/letsencrypt/live/$domain"
+mkdir -p "$data_path/conf/live/$domain"
+docker compose run --rm --entrypoint "\
   openssl req -x509 -nodes -newkey rsa:$rsa_key_size -days 1\
     -keyout '$path/privkey.pem' \
     -out '$path/fullchain.pem' \
     -subj '/CN=localhost'" certbot
 echo
 
-
+# ─── Start nginx with dummy cert ───────────────────────────
 echo "### Starting nginx ..."
-docker-compose up --force-recreate -d nginx
+docker compose up --force-recreate -d nginx
 echo
 
-echo "### Deleting dummy certificate for $domains ..."
-docker-compose run --rm --entrypoint "\
-  rm -Rf /etc/letsencrypt/live/$domains && \
-  rm -Rf /etc/letsencrypt/archive/$domains && \
-  rm -Rf /etc/letsencrypt/renewal/$domains.conf" certbot
+# ─── Delete dummy cert ─────────────────────────────────────
+echo "### Deleting dummy certificate for $domain ..."
+docker compose run --rm --entrypoint "\
+  rm -Rf /etc/letsencrypt/live/$domain && \
+  rm -Rf /etc/letsencrypt/archive/$domain && \
+  rm -Rf /etc/letsencrypt/renewal/$domain.conf" certbot
 echo
 
+# ─── Request real cert ─────────────────────────────────────
+echo "### Requesting Let's Encrypt certificate for $domain ..."
 
-echo "### Requesting Let's Encrypt certificate for $domains ..."
-#Join $domains to -d args
-domain_args=""
-for domain in "${domains[@]}"; do
-  domain_args="$domain_args -d $domain"
-done
+domain_args="-d $domain"
 
-# Select appropriate email arg
 case "$email" in
   "") email_arg="--register-unsafely-without-email" ;;
   *) email_arg="--email $email" ;;
 esac
 
-# Enable staging mode if needed
-if [ $staging != "0" ]; then staging_arg="--staging"; fi
+staging_arg=""
+if [ "$staging" != "0" ]; then staging_arg="--staging"; fi
 
-docker-compose run --rm --entrypoint "\
+docker compose run --rm --entrypoint "\
   certbot certonly --webroot -w /var/www/certbot \
     $staging_arg \
     $email_arg \
@@ -77,4 +77,4 @@ docker-compose run --rm --entrypoint "\
 echo
 
 echo "### Reloading nginx ..."
-docker-compose exec nginx nginx -s reload
+docker compose exec nginx nginx -s reload

--- a/setup.sh
+++ b/setup.sh
@@ -1,0 +1,204 @@
+#!/bin/bash
+set -e
+
+# ─── Colors ────────────────────────────────────────────────
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+CYAN='\033[0;36m'
+NC='\033[0m' # No Color
+
+# ─── Helpers ───────────────────────────────────────────────
+error()   { echo -e "${RED}[ERROR]${NC} $*" >&2; }
+info()    { echo -e "${CYAN}[INFO]${NC}  $*"; }
+success() { echo -e "${GREEN}[OK]${NC}    $*"; }
+warn()    { echo -e "${YELLOW}[WARN]${NC}  $*"; }
+prompt()  { echo -e "${CYAN}$*${NC}"; }
+
+# ─── Prereqs ───────────────────────────────────────────────
+check_prereqs() {
+  info "Checking prerequisites..."
+
+  if ! command -v docker &>/dev/null; then
+    error "Docker is not installed or not in PATH."
+    error "Install Docker: https://docs.docker.com/get-docker/"
+    exit 1
+  fi
+  success "Docker found"
+
+  if ! docker info &>/dev/null; then
+    error "Docker daemon is not running. Start Docker and try again."
+    exit 1
+  fi
+  success "Docker daemon is running"
+
+  if ! docker compose version &>/dev/null; then
+    error "Docker Compose plugin is not installed."
+    error "Install it: https://docs.docker.com/compose/install/"
+    exit 1
+  fi
+  success "Docker Compose found"
+
+  if ! command -v curl &>/dev/null; then
+    error "curl is not installed or not in PATH."
+    exit 1
+  fi
+  success "curl found"
+
+  # Ports 80 and 443
+  for port in 80 443; do
+    if command -v lsof &>/dev/null; then
+      if lsof -i :"$port" &>/dev/null; then
+        warn "Port $port is already in use. Proceeding anyway..."
+      fi
+    fi
+  done
+
+  echo
+}
+
+# ─── Input ─────────────────────────────────────────────────
+collect_input() {
+  info "Fill in the configuration (press Enter to accept defaults)"
+  echo
+
+  # Domain
+  while true; do
+    prompt "  Domain name (e.g. example.com):"
+    read -r DOMAIN_NAME
+    if [[ -z "$DOMAIN_NAME" ]]; then
+      error "Domain name is required."
+      continue
+    fi
+    # Strip protocol if pasted
+    DOMAIN_NAME=$(echo "$DOMAIN_NAME" | sed -E 's|^https?://||' | sed 's|/.*||')
+    break
+  done
+
+  # Email
+  prompt "  Email for Let's Encrypt notifications (leave empty to skip):"
+  read -r CERTBOT_EMAIL
+
+  # Staging
+  prompt "  Use staging certificates? (y/N) — use 'y' for testing to avoid rate limits:"
+  read -r staging_input
+  if [[ "$staging_input" =~ ^[Yy]$ ]]; then
+    CERTBOT_STAGING=1
+    warn "Staging mode enabled — certificate will NOT be trusted by browsers."
+  else
+    CERTBOT_STAGING=0
+  fi
+
+  echo
+}
+
+# ─── Generate .env ─────────────────────────────────────────
+generate_env() {
+  if [[ -f .env ]]; then
+    warn ".env already exists."
+    prompt "  Overwrite? (y/N):"
+    read -r overwrite
+    if [[ ! "$overwrite" =~ ^[Yy]$ ]]; then
+      warn "Keeping existing .env. Using its values."
+      export $(grep -v '^#' .env | xargs)
+      return
+    fi
+  fi
+
+  info "Generating .env..."
+  cat > .env <<EOF
+NGINX_VERSION=1.21-alpine
+NGINX_CONF_DIR=./data/nginx/conf.d
+DOMAIN_NAME=${DOMAIN_NAME}
+CERTBOT_EMAIL=${CERTBOT_EMAIL}
+CERTBOT_STAGING=${CERTBOT_STAGING}
+
+CERTBOT_CONF_DIR=./data/certbot/conf
+CERTBOT_WWW_DIR=./data/certbot/www
+
+SITES_DIR=./sites
+EOF
+
+  success ".env created"
+  echo
+}
+
+# ─── Confirm ───────────────────────────────────────────────
+confirm() {
+  echo
+  info "Configuration summary:"
+  echo -e "  Domain:   ${GREEN}${DOMAIN_NAME}${NC}"
+  echo -e "  Email:    ${GREEN}${CERTBOT_EMAIL:-not set}${NC}"
+  echo -e "  Staging:  ${GREEN}$([ "$CERTBOT_STAGING" = "1" ] && echo Yes || echo No)${NC}"
+  echo
+
+  prompt "  Start setup? (y/N):"
+  read -r confirm_input
+  if [[ ! "$confirm_input" =~ ^[Yy]$ ]]; then
+    info "Aborted."
+    exit 0
+  fi
+  echo
+}
+
+# ─── Run init ──────────────────────────────────────────────
+run_init() {
+  info "Obtaining SSL certificate..."
+  echo
+
+  if ! bash ./init-letsencrypt.sh; then
+    error "Certificate setup failed."
+    error "Check the output above for details."
+    error "Common issues:"
+    error "  - Domain does not resolve to this server's IP"
+    error "  - Port 80 is blocked by firewall"
+    error "  - Let's Encrypt rate limit reached (use staging mode)"
+    exit 1
+  fi
+
+  success "SSL certificate obtained"
+  echo
+}
+
+# ─── Start server ──────────────────────────────────────────
+start_server() {
+  info "Starting server..."
+  echo
+
+  if ! docker compose up --force-recreate -d; then
+    error "Failed to start containers."
+    error "Run 'docker compose logs' to see details."
+    exit 1
+  fi
+
+  echo
+  success "Server is running!"
+  echo
+  if [[ "$CERTBOT_STAGING" = "1" ]]; then
+    warn "Using staging certificate — browser will show a security warning. This is normal for testing."
+  fi
+  echo -e "  Visit: ${GREEN}https://${DOMAIN_NAME}${NC}"
+  echo
+  info "Logs: docker compose logs -f"
+  info "Stop:  docker compose down"
+  echo
+}
+
+# ─── Main ──────────────────────────────────────────────────
+main() {
+  echo
+  echo -e "${GREEN}=====================================${NC}"
+  echo -e "${GREEN}   nginx + Let's Encrypt SSL Setup    ${NC}"
+  echo -e "${GREEN}=====================================${NC}"
+  echo -e "  ${CYAN}https://github.com/shoom1337/nginx-certbot${NC}"
+  echo
+
+  check_prereqs
+  collect_input
+  generate_env
+  confirm
+  run_init
+  start_server
+}
+
+main


### PR DESCRIPTION
- setup.sh: единый скрипт запуска — собирает ввод, генерирует .env, получает SSL-сертификат и стартует сервер
- init-letsencrypt.sh: убрана интерактивная логика, читает всё из .env, docker-compose -> docker compose
- app.conf-template: домен через envsubst ${DOMAIN_NAME}
- docker-compose.yml: передача DOMAIN_NAME в контейнер, envsubst в command
- .env-example: добавлены DOMAIN_NAME, CERTBOT_EMAIL, CERTBOT_STAGING
- .gitignore: data/certbot/ и app.conf (runtime), темплейт отслеживается
- README.md: инструкция, структура проекта, troubleshooting