### PR TITLE
Fix YAML syntax error in ci.yml line 42

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,7 +39,8 @@ jobs:
         run: dos2unix docker-compose.yml
 
       - name: Validate docker-compose.yml syntax
-        run: yamllint -d "{extends: default, rules: {line-length: disable, trailing-spaces: disable}}" docker-compose.yml
+        run: |
+          yamllint -d "{extends: default, rules: {line-length: disable, trailing-spaces: disable}}" docker-compose.yml
 
       - name: Check all .env-example variables are used in docker-compose.yml or scripts
         run: |

--- a/init-letsencrypt.sh
+++ b/init-letsencrypt.sh
@@ -6,7 +6,7 @@ if [ ! -f .env ]; then
   echo '[ERROR] .env file not found. Run setup.sh first.' >&2
   exit 1
 fi
-while IFS= read -r line; do export "$line"; done < <(grep -v '^#' .env | grep -v '^$')
+while IFS='=' read -r key value; do export "$key=$value"; done < <(grep -v '^#' .env | grep -v '^$')
 
 # ─── Variables ─────────────────────────────────────────────
 domain="$DOMAIN_NAME"

--- a/init-letsencrypt.sh
+++ b/init-letsencrypt.sh
@@ -6,8 +6,7 @@ if [ ! -f .env ]; then
   echo '[ERROR] .env file not found. Run setup.sh first.' >&2
   exit 1
 fi
-vars=$(grep -v '^#' .env | xargs)
-export $vars
+while IFS= read -r line; do export "$line"; done < <(grep -v '^#' .env | grep -v '^$')
 
 # ─── Variables ─────────────────────────────────────────────
 domain="$DOMAIN_NAME"

--- a/setup.sh
+++ b/setup.sh
@@ -100,7 +100,7 @@ generate_env() {
     read -r overwrite
     if [[ ! "$overwrite" =~ ^[Yy]$ ]]; then
       warn "Keeping existing .env. Using its values."
-      while IFS= read -r line; do export "$line"; done < <(grep -v '^#' .env | grep -v '^$')
+      while IFS='=' read -r key value; do export "$key=$value"; done < <(grep -v '^#' .env | grep -v '^$')
       return
     fi
   fi

--- a/setup.sh
+++ b/setup.sh
@@ -100,8 +100,7 @@ generate_env() {
     read -r overwrite
     if [[ ! "$overwrite" =~ ^[Yy]$ ]]; then
       warn "Keeping existing .env. Using its values."
-      vars=$(grep -v '^#' .env | xargs)
-      export $vars
+      while IFS= read -r line; do export "$line"; done < <(grep -v '^#' .env | grep -v '^$')
       return
     fi
   fi


### PR DESCRIPTION
Обернул yamllint-команду в блочный синтаксис (|), иначе фигурные скобки в аргументе -d парсились как YAML-объект.